### PR TITLE
fix: correct endpoint mapping and require apiKey for cloud/local modes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,8 +60,8 @@ App → GunsoleClient.log() → InternalLogEntry → Batch Array → Auto-flush 
 ### Configuration Modes
 
 - `"cloud"`: https://api.gunsole.com
-- `"desktop"`: http://localhost:8787
-- `"local"`: http://localhost:17655
+- `"desktop"`: http://localhost:17655
+- `"local"`: https://local.gunsole.com
 
 ### Public Exports (src/index.ts)
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ pnpm format      # Format only
 
 All test apps are configured to use:
 
-- **Mode**: `local` (connects to `http://localhost:8787`)
+- **Mode**: `local` (connects to `https://local.gunsole.com`)
 - **Project ID**: `test-project-{framework}`
 - **API Key**: `test-api-key`
 

--- a/docs/sdk-reference.md
+++ b/docs/sdk-reference.md
@@ -55,8 +55,8 @@ const gunsole = createGunsoleClient({
 | Mode        | Endpoint                    |
 | ----------- | --------------------------- |
 | `"cloud"`   | `https://api.gunsole.com`   |
-| `"desktop"` | `http://localhost:8787`     |
-| `"local"`   | `http://localhost:17655`    |
+| `"desktop"` | `http://localhost:17655`    |
+| `"local"`   | `https://local.gunsole.com` |
 
 Setting `endpoint` overrides the mode default.
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -102,8 +102,8 @@ await gunsole.flush();
 ### Modes
 
 - `cloud`: Sends logs to `https://api.gunsole.com` (default for SaaS)
-- `desktop`: Sends logs to `http://localhost:8787` (Gunsole Desktop app)
-- `local`: Sends logs to `http://localhost:17655` (local development)
+- `desktop`: Sends logs to `http://localhost:17655` (Gunsole Desktop app)
+- `local`: Sends logs to `https://local.gunsole.com` (local development)
 
 ### Options
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gunsole/core",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Gunsole JavaScript/TypeScript SDK for browser and Node.js",
   "type": "module",
   "sideEffects": false,

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -4,8 +4,8 @@ import type { ClientMode, GunsoleClientConfig } from "./types";
  * Default endpoints for each mode
  */
 const DEFAULT_ENDPOINTS: Record<ClientMode, string> = {
-  desktop: "http://localhost:8787",
-  local: "http://localhost:17655",
+  desktop: "http://localhost:17655",
+  local: "https://local.gunsole.com",
   cloud: "https://api.gunsole.com",
 };
 
@@ -23,7 +23,7 @@ const DEFAULT_CONFIG = {
  */
 export function resolveEndpoint(
   mode: ClientMode,
-  customEndpoint?: string
+  customEndpoint?: string,
 ): string {
   if (customEndpoint) {
     return customEndpoint;
@@ -45,6 +45,9 @@ export function normalizeConfig(config: GunsoleClientConfig): Omit<
 } {
   if (!config.projectId) {
     throw new Error("projectId is required");
+  }
+  if (!config.apiKey && config.mode !== "desktop") {
+    throw new Error("apiKey is required for cloud and local modes");
   }
   if (config.batchSize !== undefined && config.batchSize < 1) {
     throw new Error("batchSize must be at least 1");

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -23,7 +23,7 @@ const DEFAULT_CONFIG = {
  */
 export function resolveEndpoint(
   mode: ClientMode,
-  customEndpoint?: string,
+  customEndpoint?: string
 ): string {
   if (customEndpoint) {
     return customEndpoint;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -3,7 +3,7 @@
  */
 export type FetchFunction = (
   input: RequestInfo | URL,
-  init?: RequestInit
+  init?: RequestInit,
 ) => Promise<Response>;
 
 /**
@@ -92,7 +92,7 @@ export interface GunsoleHooks {
 export interface GunsoleClientConfig {
   /** Project identifier */
   projectId: string;
-  /** API key (public or secret). Required for cloud mode. */
+  /** API key (public or secret). Required for cloud and local modes. */
   apiKey?: string;
   /** Client mode (desktop/local/cloud) */
   mode: ClientMode;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -3,7 +3,7 @@
  */
 export type FetchFunction = (
   input: RequestInfo | URL,
-  init?: RequestInit,
+  init?: RequestInit
 ) => Promise<Response>;
 
 /**

--- a/packages/core/tests/client.test.ts
+++ b/packages/core/tests/client.test.ts
@@ -675,6 +675,7 @@ describe("Config getters", () => {
   it("should expose projectId", () => {
     const client = createGunsoleClient({
       projectId: "my-project",
+      apiKey: "test-key",
       mode: "cloud",
     });
     expect(client.projectId).toBe("my-project");
@@ -694,6 +695,7 @@ describe("Config getters", () => {
   it("should expose logEndpoint with default cloud endpoint", () => {
     const client = createGunsoleClient({
       projectId: "test",
+      apiKey: "test-key",
       mode: "cloud",
     });
     expect(client.logEndpoint).toBe("https://api.gunsole.com/logs");
@@ -703,6 +705,7 @@ describe("Config getters", () => {
   it("should expose logEndpoint with custom endpoint", () => {
     const client = createGunsoleClient({
       projectId: "test",
+      apiKey: "test-key",
       mode: "cloud",
       endpoint: "https://custom.example.com",
     });

--- a/packages/core/tests/config.test.ts
+++ b/packages/core/tests/config.test.ts
@@ -7,11 +7,11 @@ describe("resolveEndpoint", () => {
   });
 
   it("should return desktop endpoint", () => {
-    expect(resolveEndpoint("desktop")).toBe("http://localhost:8787");
+    expect(resolveEndpoint("desktop")).toBe("http://localhost:17655");
   });
 
   it("should return local endpoint", () => {
-    expect(resolveEndpoint("local")).toBe("http://localhost:17655");
+    expect(resolveEndpoint("local")).toBe("https://local.gunsole.com");
   });
 
   it("should use custom endpoint when provided", () => {
@@ -28,13 +28,34 @@ describe("normalizeConfig", () => {
     );
   });
 
+  it("should throw if apiKey is missing for cloud mode", () => {
+    expect(() =>
+      normalizeConfig({ projectId: "test", mode: "cloud" })
+    ).toThrow("apiKey is required for cloud and local modes");
+  });
+
+  it("should throw if apiKey is missing for local mode", () => {
+    expect(() =>
+      normalizeConfig({ projectId: "test", mode: "local" })
+    ).toThrow("apiKey is required for cloud and local modes");
+  });
+
+  it("should not require apiKey for desktop mode", () => {
+    const config = normalizeConfig({
+      projectId: "test",
+      mode: "desktop",
+    });
+    expect(config.apiKey).toBe("");
+  });
+
   it("should apply default values", () => {
     const config = normalizeConfig({
       projectId: "test",
+      apiKey: "test-key",
       mode: "cloud",
     });
 
-    expect(config.apiKey).toBe("");
+    expect(config.apiKey).toBe("test-key");
     expect(config.env).toBe("");
     expect(config.appName).toBe("");
     expect(config.appVersion).toBe("");
@@ -49,12 +70,13 @@ describe("normalizeConfig", () => {
       projectId: "test",
       mode: "desktop",
     });
-    expect(config.endpoint).toBe("http://localhost:8787");
+    expect(config.endpoint).toBe("http://localhost:17655");
   });
 
   it("should allow custom endpoint to override mode", () => {
     const config = normalizeConfig({
       projectId: "test",
+      apiKey: "test-key",
       mode: "cloud",
       endpoint: "https://custom.example.com",
     });
@@ -88,27 +110,28 @@ describe("normalizeConfig", () => {
 
   it("should throw if batchSize is less than 1", () => {
     expect(() =>
-      normalizeConfig({ projectId: "test", mode: "cloud", batchSize: 0 })
+      normalizeConfig({ projectId: "test", apiKey: "k", mode: "cloud", batchSize: 0 })
     ).toThrow("batchSize must be at least 1");
 
     expect(() =>
-      normalizeConfig({ projectId: "test", mode: "cloud", batchSize: -5 })
+      normalizeConfig({ projectId: "test", apiKey: "k", mode: "cloud", batchSize: -5 })
     ).toThrow("batchSize must be at least 1");
   });
 
   it("should throw if flushInterval is less than 100ms", () => {
     expect(() =>
-      normalizeConfig({ projectId: "test", mode: "cloud", flushInterval: 0 })
+      normalizeConfig({ projectId: "test", apiKey: "k", mode: "cloud", flushInterval: 0 })
     ).toThrow("flushInterval must be at least 100ms");
 
     expect(() =>
-      normalizeConfig({ projectId: "test", mode: "cloud", flushInterval: 50 })
+      normalizeConfig({ projectId: "test", apiKey: "k", mode: "cloud", flushInterval: 50 })
     ).toThrow("flushInterval must be at least 100ms");
   });
 
   it("should accept valid batchSize and flushInterval", () => {
     const config = normalizeConfig({
       projectId: "test",
+      apiKey: "k",
       mode: "cloud",
       batchSize: 1,
       flushInterval: 100,
@@ -120,6 +143,7 @@ describe("normalizeConfig", () => {
   it("should default maxQueueSize to 1000", () => {
     const config = normalizeConfig({
       projectId: "test",
+      apiKey: "k",
       mode: "cloud",
     });
     expect(config.maxQueueSize).toBe(1000);
@@ -128,6 +152,7 @@ describe("normalizeConfig", () => {
   it("should pass through custom maxQueueSize", () => {
     const config = normalizeConfig({
       projectId: "test",
+      apiKey: "k",
       mode: "cloud",
       maxQueueSize: 500,
     });
@@ -136,11 +161,11 @@ describe("normalizeConfig", () => {
 
   it("should throw if maxQueueSize is less than 1", () => {
     expect(() =>
-      normalizeConfig({ projectId: "test", mode: "cloud", maxQueueSize: 0 })
+      normalizeConfig({ projectId: "test", apiKey: "k", mode: "cloud", maxQueueSize: 0 })
     ).toThrow("maxQueueSize must be at least 1");
 
     expect(() =>
-      normalizeConfig({ projectId: "test", mode: "cloud", maxQueueSize: -5 })
+      normalizeConfig({ projectId: "test", apiKey: "k", mode: "cloud", maxQueueSize: -5 })
     ).toThrow("maxQueueSize must be at least 1");
   });
 });

--- a/packages/core/tests/config.test.ts
+++ b/packages/core/tests/config.test.ts
@@ -29,15 +29,15 @@ describe("normalizeConfig", () => {
   });
 
   it("should throw if apiKey is missing for cloud mode", () => {
-    expect(() =>
-      normalizeConfig({ projectId: "test", mode: "cloud" })
-    ).toThrow("apiKey is required for cloud and local modes");
+    expect(() => normalizeConfig({ projectId: "test", mode: "cloud" })).toThrow(
+      "apiKey is required for cloud and local modes"
+    );
   });
 
   it("should throw if apiKey is missing for local mode", () => {
-    expect(() =>
-      normalizeConfig({ projectId: "test", mode: "local" })
-    ).toThrow("apiKey is required for cloud and local modes");
+    expect(() => normalizeConfig({ projectId: "test", mode: "local" })).toThrow(
+      "apiKey is required for cloud and local modes"
+    );
   });
 
   it("should not require apiKey for desktop mode", () => {
@@ -110,21 +110,41 @@ describe("normalizeConfig", () => {
 
   it("should throw if batchSize is less than 1", () => {
     expect(() =>
-      normalizeConfig({ projectId: "test", apiKey: "k", mode: "cloud", batchSize: 0 })
+      normalizeConfig({
+        projectId: "test",
+        apiKey: "k",
+        mode: "cloud",
+        batchSize: 0,
+      })
     ).toThrow("batchSize must be at least 1");
 
     expect(() =>
-      normalizeConfig({ projectId: "test", apiKey: "k", mode: "cloud", batchSize: -5 })
+      normalizeConfig({
+        projectId: "test",
+        apiKey: "k",
+        mode: "cloud",
+        batchSize: -5,
+      })
     ).toThrow("batchSize must be at least 1");
   });
 
   it("should throw if flushInterval is less than 100ms", () => {
     expect(() =>
-      normalizeConfig({ projectId: "test", apiKey: "k", mode: "cloud", flushInterval: 0 })
+      normalizeConfig({
+        projectId: "test",
+        apiKey: "k",
+        mode: "cloud",
+        flushInterval: 0,
+      })
     ).toThrow("flushInterval must be at least 100ms");
 
     expect(() =>
-      normalizeConfig({ projectId: "test", apiKey: "k", mode: "cloud", flushInterval: 50 })
+      normalizeConfig({
+        projectId: "test",
+        apiKey: "k",
+        mode: "cloud",
+        flushInterval: 50,
+      })
     ).toThrow("flushInterval must be at least 100ms");
   });
 
@@ -161,11 +181,21 @@ describe("normalizeConfig", () => {
 
   it("should throw if maxQueueSize is less than 1", () => {
     expect(() =>
-      normalizeConfig({ projectId: "test", apiKey: "k", mode: "cloud", maxQueueSize: 0 })
+      normalizeConfig({
+        projectId: "test",
+        apiKey: "k",
+        mode: "cloud",
+        maxQueueSize: 0,
+      })
     ).toThrow("maxQueueSize must be at least 1");
 
     expect(() =>
-      normalizeConfig({ projectId: "test", apiKey: "k", mode: "cloud", maxQueueSize: -5 })
+      normalizeConfig({
+        projectId: "test",
+        apiKey: "k",
+        mode: "cloud",
+        maxQueueSize: -5,
+      })
     ).toThrow("maxQueueSize must be at least 1");
   });
 });

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gunsole/web",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Browser lifecycle utilities for @gunsole/core",
   "type": "module",
   "sideEffects": false,

--- a/packages/web/tests/factory.test.ts
+++ b/packages/web/tests/factory.test.ts
@@ -19,7 +19,7 @@ vi.mock("@gunsole/core", async (importOriginal) => {
         setDebug: vi.fn(),
         projectId: config.projectId,
         apiKey: config.apiKey,
-        logEndpoint: "http://localhost:17655/logs",
+        logEndpoint: "https://local.gunsole.com/logs",
         _config: config,
       };
     }),


### PR DESCRIPTION
## Summary
- **Fixed endpoint mapping**: `desktop` → `http://localhost:17655`, `local` → `https://local.gunsole.com`
- **apiKey validation**: now required for `cloud` and `local` modes, optional for `desktop`
- Bumped `@gunsole/core` and `@gunsole/web` to `0.2.1`

## Test plan
- [x] All 97 tests pass (70 core + 27 web)
- [x] New tests for apiKey validation (cloud, local, desktop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)